### PR TITLE
fix: correct workflow output syntax for release_required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     outputs:
-      release_required: ${{ steps.release-pr.state == 'release_required'}}
+      release_required: ${{ steps.release-pr.outputs.state == 'release_required'}}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Fixed incorrect output syntax in release.yml workflow that prevented downstream jobs from properly skipping
- Changed `steps.release-pr.state` to `steps.release-pr.outputs.state` to correctly access step outputs

## Test plan
- [ ] Verify workflow runs without syntax errors
- [ ] Confirm downstream jobs (verify-releaser, release) skip when release is not required
- [ ] Confirm downstream jobs run when release is required

🤖 Generated with [Claude Code](https://claude.ai/code)