### PR TITLE
Add previous_tag_name parameter to generateReleaseNotes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30038,6 +30038,7 @@ function run() {
                 const notes = yield generateNotes(octokit, owner, repo, {
                     tagName: nextTag || `${tagPrefix}next`,
                     target: baseBranch,
+                    previousTagName: currentTag || undefined,
                     configuration_file_path: releaseCfgPath,
                 }).catch(() => "");
                 const { title, body } = buildPRText({
@@ -30132,6 +30133,7 @@ function run() {
                     const notes = yield generateNotes(octokit, owner, repo, {
                         tagName: nextTag || `${tagPrefix}next`,
                         target: baseBranch,
+                        previousTagName: currentTag || undefined,
                         configuration_file_path: releaseCfgPath,
                     }).catch(() => "");
                     const { title, body } = buildPRText({
@@ -30172,6 +30174,7 @@ function run() {
                 const notes = yield generateNotes(octokit, owner, repo, {
                     tagName: `${tagPrefix}next`,
                     target: baseBranch,
+                    previousTagName: currentTag || undefined,
                     configuration_file_path: releaseCfgPath,
                 }).catch(() => "");
                 const { title, body } = buildPRText({
@@ -30280,12 +30283,13 @@ function calcNext(prefix, currentTag, bumpLevel) {
     return `${prefix}${major}.${minor}.${patch}`;
 }
 function generateNotes(octokit_1, owner_1, repo_1, _a) {
-    return __awaiter(this, arguments, void 0, function* (octokit, owner, repo, { tagName, target, configuration_file_path, }) {
+    return __awaiter(this, arguments, void 0, function* (octokit, owner, repo, { tagName, target, previousTagName, configuration_file_path, }) {
         const res = yield octokit.rest.repos.generateReleaseNotes({
             owner,
             repo,
             tag_name: tagName,
             target_commitish: target,
+            previous_tag_name: previousTagName,
             configuration_file_path,
         });
         return res.data.body || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ async function run(): Promise<void> {
 			const notes = await generateNotes(octokit, owner, repo, {
 				tagName: nextTag || `${tagPrefix}next`,
 				target: baseBranch,
+				previousTagName: currentTag || undefined,
 				configuration_file_path: releaseCfgPath,
 			}).catch(() => "");
 			const { title, body } = buildPRText({
@@ -191,6 +192,7 @@ async function run(): Promise<void> {
 				const notes = await generateNotes(octokit, owner, repo, {
 					tagName: nextTag || `${tagPrefix}next`,
 					target: baseBranch,
+					previousTagName: currentTag || undefined,
 					configuration_file_path: releaseCfgPath,
 				}).catch(() => "");
 				const { title, body } = buildPRText({
@@ -232,6 +234,7 @@ async function run(): Promise<void> {
 			const notes = await generateNotes(octokit, owner, repo, {
 				tagName: `${tagPrefix}next`,
 				target: baseBranch,
+				previousTagName: currentTag || undefined,
 				configuration_file_path: releaseCfgPath,
 			}).catch(() => "");
 			const { title, body } = buildPRText({
@@ -369,14 +372,16 @@ async function generateNotes(
 	{
 		tagName,
 		target,
+		previousTagName,
 		configuration_file_path,
-	}: { tagName: string; target: string; configuration_file_path?: string },
+	}: { tagName: string; target: string; previousTagName?: string; configuration_file_path?: string },
 ): Promise<string> {
 	const res = await octokit.rest.repos.generateReleaseNotes({
 		owner,
 		repo,
 		tag_name: tagName,
 		target_commitish: target,
+		previous_tag_name: previousTagName,
 		configuration_file_path,
 	});
 	return res.data.body || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,7 +374,12 @@ async function generateNotes(
 		target,
 		previousTagName,
 		configuration_file_path,
-	}: { tagName: string; target: string; previousTagName?: string; configuration_file_path?: string },
+	}: {
+		tagName: string;
+		target: string;
+		previousTagName?: string;
+		configuration_file_path?: string;
+	},
 ): Promise<string> {
 	const res = await octokit.rest.repos.generateReleaseNotes({
 		owner,


### PR DESCRIPTION
## Summary
- Added `previous_tag_name` parameter to the `generateReleaseNotes` API call
- This ensures release notes are generated with the correct scope of changes between tags

## Details
When generating release notes, the GitHub API's `generateReleaseNotes` endpoint accepts an optional `previous_tag_name` parameter. Without this parameter, the API might include more changes than intended in the release notes.

This PR updates the `generateNotes` function to:
1. Accept an optional `previousTagName` parameter
2. Pass it to the GitHub API as `previous_tag_name`
3. Use the current tag as the previous tag name when generating notes for the next release

## Test plan
- [x] TypeScript compilation passes (`npm run typecheck`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.ai/code)