### PR TITLE
refactor: improve workflow metadata display in PR description

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30399,16 +30399,6 @@ function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     parts.push("## 🚀 Release PR");
     parts.push("");
     parts.push("_Prepared by [create-release-pr](https://github.com/actionutils/create-release-pr)_");
-    // Add workflow update metadata
-    const runId = process.env.GITHUB_RUN_ID;
-    const runNumber = process.env.GITHUB_RUN_NUMBER;
-    const workflow = process.env.GITHUB_WORKFLOW;
-    const updateTime = new Date().toISOString();
-    if (runId && workflow) {
-        const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
-        parts.push("");
-        parts.push(`<sub>Last updated: ${updateTime} by [${workflow} #${runNumber || runId}](${workflowUrl})</sub>`);
-    }
     parts.push("");
     // Build the release info table
     parts.push("### Release Information");
@@ -30446,6 +30436,16 @@ function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     }
     parts.push("");
     parts.push("---");
+    // Add workflow update metadata at the end, right-aligned
+    const runId = process.env.GITHUB_RUN_ID;
+    const runNumber = process.env.GITHUB_RUN_NUMBER;
+    const workflow = process.env.GITHUB_WORKFLOW;
+    const updateTime = new Date().toISOString();
+    if (runId && workflow) {
+        const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+        parts.push("");
+        parts.push(`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by ${workflow} #${runNumber || runId}</sub></div>`);
+    }
     return { title, body: parts.join("\n") };
 }
 void run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -527,21 +527,6 @@ function buildPRText({
 	parts.push(
 		"_Prepared by [create-release-pr](https://github.com/actionutils/create-release-pr)_",
 	);
-
-	// Add workflow update metadata
-	const runId = process.env.GITHUB_RUN_ID;
-	const runNumber = process.env.GITHUB_RUN_NUMBER;
-	const workflow = process.env.GITHUB_WORKFLOW;
-	const updateTime = new Date().toISOString();
-
-	if (runId && workflow) {
-		const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
-		parts.push("");
-		parts.push(
-			`<sub>Last updated: ${updateTime} by [${workflow} #${runNumber || runId}](${workflowUrl})</sub>`,
-		);
-	}
-
 	parts.push("");
 
 	// Build the release info table
@@ -592,6 +577,20 @@ function buildPRText({
 	}
 	parts.push("");
 	parts.push("---");
+
+	// Add workflow update metadata at the end, right-aligned
+	const runId = process.env.GITHUB_RUN_ID;
+	const runNumber = process.env.GITHUB_RUN_NUMBER;
+	const workflow = process.env.GITHUB_WORKFLOW;
+	const updateTime = new Date().toISOString();
+
+	if (runId && workflow) {
+		const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+		parts.push("");
+		parts.push(
+			`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by ${workflow} #${runNumber || runId}</sub></div>`,
+		);
+	}
 
 	return { title, body: parts.join("\n") };
 }


### PR DESCRIPTION
## Summary
- Move workflow metadata to the end of PR description for better layout
- Right-align the metadata using HTML div alignment
- Make timestamp a clickable link to the workflow run

## Changes
- Relocated workflow metadata from after the header to the end of PR body
- Changed timestamp to be a clickable link pointing to the GitHub Actions workflow run
- Right-aligned the metadata using `<div align="right">` for better visual presentation

## Test plan
- [ ] Test that release PRs show workflow metadata at the bottom
- [ ] Verify the timestamp is clickable and leads to the correct workflow run
- [ ] Confirm metadata is right-aligned in the PR description
- [ ] Ensure metadata only appears when running in GitHub Actions context

🤖 Generated with [Claude Code](https://claude.ai/code)