### PR TITLE
Update release PR when labels change on closed PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32953,12 +32953,34 @@ function handlePullRequestEvent(octokit, config) {
             setOutputWithLog("state", "noop");
             return;
         }
-        if (pr.head.ref !== config.releaseBranch) {
-            core.info(`PR is not from release branch (${pr.head.ref} != ${config.releaseBranch}) - skipping`);
-            setOutputWithLog("state", "noop");
+        // Check if this is the release PR itself
+        if (pr.head.ref === config.releaseBranch) {
+            core.info("Label change on release PR - updating");
+            yield updateReleasePR(octokit, config, pr);
             return;
         }
-        yield updateReleasePR(octokit, config, pr);
+        // For closed PRs, we need to update the release PR to regenerate release notes
+        if (pr.state === "closed" && pr.merged) {
+            core.info("Label change on closed/merged PR - updating release PR notes");
+            // Find the open release PR to update
+            const releasePR = yield findOpenReleasePR(octokit, {
+                owner: config.owner,
+                repo: config.repo,
+                baseBranch: config.baseBranch,
+                releaseBranch: config.releaseBranch,
+            });
+            if (releasePR && releasePR.number) {
+                core.info(`Found release PR #${releasePR.number} - updating with new release notes`);
+                yield updateReleasePR(octokit, config, releasePR);
+            }
+            else {
+                core.info("No open release PR found - skipping");
+                setOutputWithLog("state", "noop");
+            }
+            return;
+        }
+        core.info("Label change on non-release, non-merged PR - skipping");
+        setOutputWithLog("state", "noop");
     });
 }
 function updateReleasePR(octokit, config, pr) {


### PR DESCRIPTION
## Summary
- Added logic to update release PR when labels are changed on closed/merged PRs
- This ensures release notes accurately reflect PR categorization even after merging
- Maintains existing behavior for label changes on the release PR itself

## Changes
When a `labeled` or `unlabeled` event occurs on a PR:
1. If it's the release PR itself → update it (existing behavior)
2. If it's a closed/merged PR → find and update the open release PR to regenerate notes
3. Otherwise → skip (no action needed)

## Why this matters
GitHub's release notes generation categorizes PRs based on their labels. When labels are changed on already-merged PRs (e.g., to fix categorization), the release notes need to be regenerated to reflect these changes. This PR ensures that happens automatically.

## Test plan
- [ ] Label/unlabel a closed PR and verify the release PR gets updated
- [ ] Label/unlabel the release PR itself and verify it still updates
- [ ] Label/unlabel an open non-release PR and verify no action is taken

🤖 Generated with [Claude Code](https://claude.ai/code)