### PR TITLE
refactor: simplify release PR body format

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,7 @@ changelog:
     - title: Breaking Changes 🛠
       labels:
         - breaking-change
-    - title: Deprecations ⚠️ 
+    - title: Deprecations ⚠️
       labels:
         - breaking-change
     - title: Enhancements 🎉

--- a/dist/index.js
+++ b/dist/index.js
@@ -32881,12 +32881,14 @@ function ensureAndAddLabel(octokit, owner, repo, prNumber, labelName) {
         }
     });
 }
-function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
+function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextTag, notes, }) {
     const known = !!nextTag;
     const title = known ? `Release for ${nextTag}` : "Release for new version";
     const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
     const parts = [];
     const nextTagOrTBD = nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
+    parts.push(`You can directly edit the [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`);
+    parts.push("");
     parts.push("### ↓ Release Notes Preview ↓");
     parts.push("");
     if (notes) {
@@ -32969,6 +32971,7 @@ function updateReleasePR(octokit, config, pr) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
+            releaseBranch: config.releaseBranch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33074,6 +33077,7 @@ function updateExistingReleasePR(octokit, config, existing) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
+            releaseBranch: config.releaseBranch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33118,6 +33122,7 @@ function createNewReleasePR(octokit, config, currentTag) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
+            releaseBranch: config.releaseBranch,
             currentTag: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || null,
             nextTag,
             notes,

--- a/dist/index.js
+++ b/dist/index.js
@@ -32907,7 +32907,7 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, labelMajor, label
         // Replace the Full Changelog link with a working View Diff link
         let modifiedNotes = notes;
         if (currentTag && nextTag) {
-            const fullChangelogPattern = new RegExp(`\\*\\*Full Changelog\\*\\*: ${serverUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/[^\\/]+\\/[^\\/]+\\/compare\\/[^\\.]+\\.\\.\\.[^\\s]+`, 'g');
+            const fullChangelogPattern = new RegExp(`\\*\\*Full Changelog\\*\\*: ${serverUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\/[^\\/]+\\/[^\\/]+\\/compare\\/[^\\.]+\\.\\.\\.[^\\s]+`, "g");
             const viewDiffLink = `**Full Changelog**: ${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
             modifiedNotes = notes.replace(fullChangelogPattern, viewDiffLink);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -32881,7 +32881,7 @@ function ensureAndAddLabel(octokit, owner, repo, prNumber, labelName) {
         }
     });
 }
-function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
+function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextTag, notes, }) {
     const known = !!nextTag;
     const title = known ? `Release for ${nextTag}` : "Release for new version";
     const parts = [];
@@ -32912,7 +32912,7 @@ function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     parts.push("### ↓ Release Notes Preview ↓");
     parts.push("");
     parts.push("> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.");
-    parts.push("> You can directly edit this release-pr branch to prepare for the release.");
+    parts.push(`> You can directly edit the [${releaseBranch}](https://github.com/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`);
     parts.push("> The Full Changelog link may not work until the new tag is released.");
     parts.push("");
     if (notes) {
@@ -32990,6 +32990,7 @@ function updateReleasePR(octokit, config, pr) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
+            releaseBranch: config.releaseBranch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33095,6 +33096,7 @@ function updateExistingReleasePR(octokit, config, existing) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
+            releaseBranch: config.releaseBranch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33139,6 +33141,7 @@ function createNewReleasePR(octokit, config, currentTag) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
+            releaseBranch: config.releaseBranch,
             currentTag: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || null,
             nextTag,
             notes,

--- a/dist/index.js
+++ b/dist/index.js
@@ -32912,6 +32912,7 @@ function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     parts.push("### ↓ Release Notes Preview ↓");
     parts.push("");
     parts.push("> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.");
+    parts.push("> You can directly edit this release-pr branch to prepare for the release.");
     parts.push("> The Full Changelog link may not work until the new tag is released.");
     parts.push("");
     if (notes) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -32911,10 +32911,6 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextT
     parts.push("");
     parts.push("### ↓ Release Notes Preview ↓");
     parts.push("");
-    parts.push("> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.");
-    parts.push(`> You can directly edit the [${releaseBranch}](https://github.com/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`);
-    parts.push("> The Full Changelog link may not work until the new tag is released.");
-    parts.push("");
     if (notes) {
         parts.push(`# Release ${nextTagOrTBD}`);
         parts.push("");

--- a/dist/index.js
+++ b/dist/index.js
@@ -32884,6 +32884,7 @@ function ensureAndAddLabel(octokit, owner, repo, prNumber, labelName) {
 function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextTag, notes, }) {
     const known = !!nextTag;
     const title = known ? `Release for ${nextTag}` : "Release for new version";
+    const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
     const parts = [];
     // Build the release info table
     parts.push("<details><summary>Release Information</summary>");
@@ -32892,7 +32893,7 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextT
     parts.push("|---|---|");
     // Current tag with link to release page
     if (currentTag) {
-        parts.push(`| **Current Release** | [${currentTag}](https://github.com/${owner}/${repo}/releases/tag/${currentTag}) |`);
+        parts.push(`| **Current Release** | [${currentTag}](${serverUrl}/${owner}/${repo}/releases/tag/${currentTag}) |`);
     }
     else {
         parts.push("| **Current Release** | (none) |");
@@ -32900,9 +32901,11 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextT
     const nextTagOrTBD = nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
     // Next tag
     parts.push(`| **Next Release** | ${nextTagOrTBD} |`);
+    // Release branch
+    parts.push(`| **Release Branch** | [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) |`);
     // Full changelog link
     if (currentTag) {
-        parts.push(`| **Changes** | [View Diff](https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`);
+        parts.push(`| **Changes** | [View Diff](${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`);
     }
     parts.push("");
     parts.push("</details>");
@@ -32917,8 +32920,8 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextT
         // Replace the Full Changelog link with a working View Diff link
         let modifiedNotes = notes;
         if (currentTag && nextTag) {
-            const fullChangelogPattern = /\*\*Full Changelog\*\*: https:\/\/github\.com\/[^\/]+\/[^\/]+\/compare\/[^\.]+\.\.\.[^\s]+/g;
-            const viewDiffLink = `**Full Changelog**: https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
+            const fullChangelogPattern = new RegExp(`\\*\\*Full Changelog\\*\\*: ${serverUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/[^\\/]+\\/[^\\/]+\\/compare\\/[^\\.]+\\.\\.\\.[^\\s]+`, 'g');
+            const viewDiffLink = `**Full Changelog**: ${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
             modifiedNotes = notes.replace(fullChangelogPattern, viewDiffLink);
         }
         parts.push(modifiedNotes);
@@ -32932,9 +32935,9 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextT
     const runId = process.env.GITHUB_RUN_ID;
     const updateTime = new Date().toISOString();
     if (runId) {
-        const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+        const workflowUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
         parts.push("");
-        parts.push(`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by <a href='https://github.com/actionutils/create-release-pr'>create-release-pr</a></sub></div>`);
+        parts.push(`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by <a href='${serverUrl}/actionutils/create-release-pr'>create-release-pr</a></sub></div>`);
     }
     return { title, body: parts.join("\n") };
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -32914,7 +32914,14 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextT
     if (notes) {
         parts.push(`# Release ${nextTagOrTBD}`);
         parts.push("");
-        parts.push(notes);
+        // Replace the Full Changelog link with a working View Diff link
+        let modifiedNotes = notes;
+        if (currentTag && nextTag) {
+            const fullChangelogPattern = /\*\*Full Changelog\*\*: https:\/\/github\.com\/[^\/]+\/[^\/]+\/compare\/[^\.]+\.\.\.[^\s]+/g;
+            const viewDiffLink = `**Full Changelog**: https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
+            modifiedNotes = notes.replace(fullChangelogPattern, viewDiffLink);
+        }
+        parts.push(modifiedNotes);
     }
     else {
         parts.push("_Release notes will be generated here_");

--- a/dist/index.js
+++ b/dist/index.js
@@ -32881,13 +32881,23 @@ function ensureAndAddLabel(octokit, owner, repo, prNumber, labelName) {
         }
     });
 }
-function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextTag, notes, }) {
+function buildPRText({ owner, repo, baseBranch, releaseBranch, labelMajor, labelMinor, labelPatch, currentTag, nextTag, notes, }) {
     const known = !!nextTag;
     const title = known ? `Release for ${nextTag}` : "Release for new version";
     const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
     const parts = [];
     const nextTagOrTBD = nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
     parts.push(`You can directly edit the [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`);
+    parts.push("");
+    parts.push("<details>");
+    parts.push("<summary>How to specify the next version</summary>");
+    parts.push("");
+    parts.push("Add one of the following labels to this PR to specify the version bump:");
+    parts.push(`- \`${labelMajor}\` - for major version bump (e.g., 1.0.0 → 2.0.0)`);
+    parts.push(`- \`${labelMinor}\` - for minor version bump (e.g., 1.0.0 → 1.1.0)`);
+    parts.push(`- \`${labelPatch}\` - for patch version bump (e.g., 1.0.0 → 1.0.1)`);
+    parts.push("");
+    parts.push("</details>");
     parts.push("");
     parts.push("### ↓ Release Notes Preview ↓");
     parts.push("");
@@ -32972,6 +32982,9 @@ function updateReleasePR(octokit, config, pr) {
             repo: config.repo,
             baseBranch: config.baseBranch,
             releaseBranch: config.releaseBranch,
+            labelMajor: config.labelMajor,
+            labelMinor: config.labelMinor,
+            labelPatch: config.labelPatch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33078,6 +33091,9 @@ function updateExistingReleasePR(octokit, config, existing) {
             repo: config.repo,
             baseBranch: config.baseBranch,
             releaseBranch: config.releaseBranch,
+            labelMajor: config.labelMajor,
+            labelMinor: config.labelMinor,
+            labelPatch: config.labelPatch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33123,6 +33139,9 @@ function createNewReleasePR(octokit, config, currentTag) {
             repo: config.repo,
             baseBranch: config.baseBranch,
             releaseBranch: config.releaseBranch,
+            labelMajor: config.labelMajor,
+            labelMinor: config.labelMinor,
+            labelPatch: config.labelPatch,
             currentTag: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || null,
             nextTag,
             notes,

--- a/dist/index.js
+++ b/dist/index.js
@@ -32885,12 +32885,8 @@ function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     const known = !!nextTag;
     const title = known ? `Release for ${nextTag}` : "Release for new version";
     const parts = [];
-    parts.push("## 🚀 Release PR");
-    parts.push("");
-    parts.push("_Prepared by [create-release-pr](https://github.com/actionutils/create-release-pr)_");
-    parts.push("");
     // Build the release info table
-    parts.push("### Release Information");
+    parts.push("<details><summary>Release Information</summary>");
     parts.push("");
     parts.push("| | |");
     parts.push("|---|---|");
@@ -32901,23 +32897,26 @@ function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     else {
         parts.push("| **Current Release** | (none) |");
     }
+    const nextTagOrTBD = nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
     // Next tag
-    parts.push(`| **Next Release** | ${nextTag || "⚠️ TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`"} |`);
+    parts.push(`| **Next Release** | ${nextTagOrTBD} |`);
     // Full changelog link
     if (currentTag) {
         parts.push(`| **Changes** | [View Diff](https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`);
     }
     parts.push("");
+    parts.push("</details>");
+    parts.push("");
     parts.push("---");
     parts.push("");
-    parts.push("### 📝 Release Notes Preview");
+    parts.push("### ↓ Release Notes Preview ↓");
     parts.push("");
-    parts.push("> **Note:** This is a preview of the release notes that will be published when this PR is merged.");
+    parts.push("> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.");
     parts.push("> The Full Changelog link may not work until the new tag is released.");
     parts.push("");
-    parts.push("---");
-    parts.push("");
     if (notes) {
+        parts.push(`# Release ${nextTagOrTBD}`);
+        parts.push("");
         parts.push(notes);
     }
     else {
@@ -32927,13 +32926,11 @@ function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     parts.push("---");
     // Add workflow update metadata at the end, right-aligned
     const runId = process.env.GITHUB_RUN_ID;
-    const runNumber = process.env.GITHUB_RUN_NUMBER;
-    const workflow = process.env.GITHUB_WORKFLOW;
     const updateTime = new Date().toISOString();
-    if (runId && workflow) {
+    if (runId) {
         const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
         parts.push("");
-        parts.push(`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by ${workflow} #${runNumber || runId}</sub></div>`);
+        parts.push(`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by <a href='https://github.com/actionutils/create-release-pr'>create-release-pr</a></sub></div>`);
     }
     return { title, body: parts.join("\n") };
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -32881,37 +32881,12 @@ function ensureAndAddLabel(octokit, owner, repo, prNumber, labelName) {
         }
     });
 }
-function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextTag, notes, }) {
+function buildPRText({ owner, repo, baseBranch, currentTag, nextTag, notes, }) {
     const known = !!nextTag;
     const title = known ? `Release for ${nextTag}` : "Release for new version";
     const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
     const parts = [];
-    // Build the release info table
-    parts.push("<details><summary>Release Information</summary>");
-    parts.push("");
-    parts.push("| | |");
-    parts.push("|---|---|");
-    // Current tag with link to release page
-    if (currentTag) {
-        parts.push(`| **Current Release** | [${currentTag}](${serverUrl}/${owner}/${repo}/releases/tag/${currentTag}) |`);
-    }
-    else {
-        parts.push("| **Current Release** | (none) |");
-    }
     const nextTagOrTBD = nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
-    // Next tag
-    parts.push(`| **Next Release** | ${nextTagOrTBD} |`);
-    // Release branch
-    parts.push(`| **Release Branch** | [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) |`);
-    // Full changelog link
-    if (currentTag) {
-        parts.push(`| **Changes** | [View Diff](${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`);
-    }
-    parts.push("");
-    parts.push("</details>");
-    parts.push("");
-    parts.push("---");
-    parts.push("");
     parts.push("### ↓ Release Notes Preview ↓");
     parts.push("");
     if (notes) {
@@ -32929,8 +32904,6 @@ function buildPRText({ owner, repo, baseBranch, releaseBranch, currentTag, nextT
     else {
         parts.push("_Release notes will be generated here_");
     }
-    parts.push("");
-    parts.push("---");
     // Add workflow update metadata at the end, right-aligned
     const runId = process.env.GITHUB_RUN_ID;
     const updateTime = new Date().toISOString();
@@ -32996,7 +32969,6 @@ function updateReleasePR(octokit, config, pr) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
-            releaseBranch: config.releaseBranch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33102,7 +33074,6 @@ function updateExistingReleasePR(octokit, config, existing) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
-            releaseBranch: config.releaseBranch,
             currentTag: ((_a = releaseInfo.currentTag) === null || _a === void 0 ? void 0 : _a.raw) || null,
             nextTag: releaseInfo.nextTag,
             notes: releaseInfo.notes,
@@ -33147,7 +33118,6 @@ function createNewReleasePR(octokit, config, currentTag) {
             owner: config.owner,
             repo: config.repo,
             baseBranch: config.baseBranch,
-            releaseBranch: config.releaseBranch,
             currentTag: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || null,
             nextTag,
             notes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,6 +319,7 @@ function buildPRText({
 }) {
 	const known = !!nextTag;
 	const title = known ? `Release for ${nextTag}` : "Release for new version";
+	const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
 	const parts: string[] = [];
 	// Build the release info table
 	parts.push("<details><summary>Release Information</summary>");
@@ -329,7 +330,7 @@ function buildPRText({
 	// Current tag with link to release page
 	if (currentTag) {
 		parts.push(
-			`| **Current Release** | [${currentTag}](https://github.com/${owner}/${repo}/releases/tag/${currentTag}) |`,
+			`| **Current Release** | [${currentTag}](${serverUrl}/${owner}/${repo}/releases/tag/${currentTag}) |`,
 		);
 	} else {
 		parts.push("| **Current Release** | (none) |");
@@ -341,10 +342,13 @@ function buildPRText({
 	// Next tag
 	parts.push(`| **Next Release** | ${nextTagOrTBD} |`);
 
+	// Release branch
+	parts.push(`| **Release Branch** | [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) |`);
+
 	// Full changelog link
 	if (currentTag) {
 		parts.push(
-			`| **Changes** | [View Diff](https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`,
+			`| **Changes** | [View Diff](${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`,
 		);
 	}
 	parts.push("");
@@ -361,8 +365,8 @@ function buildPRText({
 		// Replace the Full Changelog link with a working View Diff link
 		let modifiedNotes = notes;
 		if (currentTag && nextTag) {
-			const fullChangelogPattern = /\*\*Full Changelog\*\*: https:\/\/github\.com\/[^\/]+\/[^\/]+\/compare\/[^\.]+\.\.\.[^\s]+/g;
-			const viewDiffLink = `**Full Changelog**: https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
+			const fullChangelogPattern = new RegExp(`\\*\\*Full Changelog\\*\\*: ${serverUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/[^\\/]+\\/[^\\/]+\\/compare\\/[^\\.]+\\.\\.\\.[^\\s]+`, 'g');
+			const viewDiffLink = `**Full Changelog**: ${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
 			modifiedNotes = notes.replace(fullChangelogPattern, viewDiffLink);
 		}
 		parts.push(modifiedNotes);
@@ -377,10 +381,10 @@ function buildPRText({
 	const updateTime = new Date().toISOString();
 
 	if (runId) {
-		const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+		const workflowUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
 		parts.push("");
 		parts.push(
-			`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by <a href='https://github.com/actionutils/create-release-pr'>create-release-pr</a></sub></div>`,
+			`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by <a href='${serverUrl}/actionutils/create-release-pr'>create-release-pr</a></sub></div>`,
 		);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,15 +318,8 @@ function buildPRText({
 	const known = !!nextTag;
 	const title = known ? `Release for ${nextTag}` : "Release for new version";
 	const parts: string[] = [];
-	parts.push("## 🚀 Release PR");
-	parts.push("");
-	parts.push(
-		"_Prepared by [create-release-pr](https://github.com/actionutils/create-release-pr)_",
-	);
-	parts.push("");
-
 	// Build the release info table
-	parts.push("### Release Information");
+	parts.push("<details><summary>Release Information</summary>");
 	parts.push("");
 	parts.push("| | |");
 	parts.push("|---|---|");
@@ -340,9 +333,11 @@ function buildPRText({
 		parts.push("| **Current Release** | (none) |");
 	}
 
+  const nextTagOrTBD = nextTag || "⚠️ TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
+
 	// Next tag
 	parts.push(
-		`| **Next Release** | ${nextTag || "⚠️ TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`"} |`,
+		`| **Next Release** | ${nextTagOrTBD} |`,
 	);
 
 	// Full changelog link
@@ -351,22 +346,24 @@ function buildPRText({
 			`| **Changes** | [View Diff](https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`,
 		);
 	}
+	parts.push("");
+	parts.push("</details>");
 
 	parts.push("");
 	parts.push("---");
 	parts.push("");
-	parts.push("### 📝 Release Notes Preview");
+	parts.push("### ↓ Release Notes Preview ↓");
 	parts.push("");
 	parts.push(
-		"> **Note:** This is a preview of the release notes that will be published when this PR is merged.",
+		"> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.",
 	);
 	parts.push(
 		"> The Full Changelog link may not work until the new tag is released.",
 	);
 	parts.push("");
-	parts.push("---");
-	parts.push("");
 	if (notes) {
+    parts.push(`# Release ${nextTagOrTBD}`);
+    parts.push("");
 		parts.push(notes);
 	} else {
 		parts.push("_Release notes will be generated here_");
@@ -376,15 +373,13 @@ function buildPRText({
 
 	// Add workflow update metadata at the end, right-aligned
 	const runId = process.env.GITHUB_RUN_ID;
-	const runNumber = process.env.GITHUB_RUN_NUMBER;
-	const workflow = process.env.GITHUB_WORKFLOW;
 	const updateTime = new Date().toISOString();
 
 	if (runId && workflow) {
 		const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
-		parts.push("");
+    parts.push("");
 		parts.push(
-			`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by ${workflow} #${runNumber || runId}</sub></div>`,
+			`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by <a href='https://github.com/actionutils/create-release-pr'>create-release-pr</a></sub></div>`,
 		);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,9 @@ function buildPRText({
 	repo,
 	baseBranch,
 	releaseBranch,
+	labelMajor,
+	labelMinor,
+	labelPatch,
 	currentTag,
 	nextTag,
 	notes,
@@ -313,6 +316,9 @@ function buildPRText({
 	repo: string;
 	baseBranch: string;
 	releaseBranch: string;
+	labelMajor: string;
+	labelMinor: string;
+	labelPatch: string;
 	currentTag: string | null;
 	nextTag: string;
 	notes: string;
@@ -326,6 +332,16 @@ function buildPRText({
 		nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
 
 	parts.push(`You can directly edit the [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`);
+	parts.push("");
+	parts.push("<details>");
+	parts.push("<summary>How to specify the next version</summary>");
+	parts.push("");
+	parts.push("Add one of the following labels to this PR to specify the version bump:");
+	parts.push(`- \`${labelMajor}\` - for major version bump (e.g., 1.0.0 → 2.0.0)`);
+	parts.push(`- \`${labelMinor}\` - for minor version bump (e.g., 1.0.0 → 1.1.0)`);
+	parts.push(`- \`${labelPatch}\` - for patch version bump (e.g., 1.0.0 → 1.0.1)`);
+	parts.push("");
+	parts.push("</details>");
 	parts.push("");
 	parts.push("### ↓ Release Notes Preview ↓");
 	parts.push("");
@@ -432,6 +448,9 @@ async function updateReleasePR(
 		repo: config.repo,
 		baseBranch: config.baseBranch,
 		releaseBranch: config.releaseBranch,
+		labelMajor: config.labelMajor,
+		labelMinor: config.labelMinor,
+		labelPatch: config.labelPatch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -565,6 +584,9 @@ async function updateExistingReleasePR(
 		repo: config.repo,
 		baseBranch: config.baseBranch,
 		releaseBranch: config.releaseBranch,
+		labelMajor: config.labelMajor,
+		labelMinor: config.labelMinor,
+		labelPatch: config.labelPatch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -619,6 +641,9 @@ async function createNewReleasePR(
 		repo: config.repo,
 		baseBranch: config.baseBranch,
 		releaseBranch: config.releaseBranch,
+		labelMajor: config.labelMajor,
+		labelMinor: config.labelMinor,
+		labelPatch: config.labelPatch,
 		currentTag: currentTag?.raw || null,
 		nextTag,
 		notes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,7 +358,14 @@ function buildPRText({
 	if (notes) {
 		parts.push(`# Release ${nextTagOrTBD}`);
 		parts.push("");
-		parts.push(notes);
+		// Replace the Full Changelog link with a working View Diff link
+		let modifiedNotes = notes;
+		if (currentTag && nextTag) {
+			const fullChangelogPattern = /\*\*Full Changelog\*\*: https:\/\/github\.com\/[^\/]+\/[^\/]+\/compare\/[^\.]+\.\.\.[^\s]+/g;
+			const viewDiffLink = `**Full Changelog**: https://github.com/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
+			modifiedNotes = notes.replace(fullChangelogPattern, viewDiffLink);
+		}
+		parts.push(modifiedNotes);
 	} else {
 		parts.push("_Release notes will be generated here_");
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,6 +357,9 @@ function buildPRText({
 		"> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.",
 	);
 	parts.push(
+		"> You can directly edit this release-pr branch to prepare for the release.",
+	);
+	parts.push(
 		"> The Full Changelog link may not work until the new tag is released.",
 	);
 	parts.push("");

--- a/src/index.ts
+++ b/src/index.ts
@@ -353,11 +353,11 @@ function buildPRText({
 	parts.push("");
 	parts.push("</details>");
 	parts.push("");
-	parts.push("### ↓ Release Notes Preview ↓");
-	parts.push("");
 	if (notes) {
-		parts.push(`# Release ${nextTag || "<TBD>"}`);
-		parts.push("");
+		if (nextTag) {
+			parts.push(`# Release ${nextTag}`);
+			parts.push("");
+		}
 		// Replace the Full Changelog link to use baseBranch instead of nextTag
 		let modifiedNotes = notes;
 		if (currentTag && nextTag) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,9 +328,6 @@ function buildPRText({
 	const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
 	const parts: string[] = [];
 
-	const nextTagOrTBD =
-		nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
-
 	parts.push(
 		`You can directly edit the [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`,
 	);
@@ -366,7 +363,10 @@ function buildPRText({
 				`(\\*\\*Full Changelog\\*\\*: .*\\/compare\\/)${currentTag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.\\.\\.${nextTag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
 				"g",
 			);
-			modifiedNotes = notes.replace(fullChangelogPattern, `$1${currentTag}...${baseBranch}`);
+			modifiedNotes = notes.replace(
+				fullChangelogPattern,
+				`$1${currentTag}...${baseBranch}`,
+			);
 		}
 		parts.push(modifiedNotes);
 	} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,15 +331,25 @@ function buildPRText({
 	const nextTagOrTBD =
 		nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
 
-	parts.push(`You can directly edit the [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`);
+	parts.push(
+		`You can directly edit the [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`,
+	);
 	parts.push("");
 	parts.push("<details>");
 	parts.push("<summary>How to specify the next version</summary>");
 	parts.push("");
-	parts.push("Add one of the following labels to this PR to specify the version bump:");
-	parts.push(`- \`${labelMajor}\` - for major version bump (e.g., 1.0.0 → 2.0.0)`);
-	parts.push(`- \`${labelMinor}\` - for minor version bump (e.g., 1.0.0 → 1.1.0)`);
-	parts.push(`- \`${labelPatch}\` - for patch version bump (e.g., 1.0.0 → 1.0.1)`);
+	parts.push(
+		"Add one of the following labels to this PR to specify the version bump:",
+	);
+	parts.push(
+		`- \`${labelMajor}\` - for major version bump (e.g., 1.0.0 → 2.0.0)`,
+	);
+	parts.push(
+		`- \`${labelMinor}\` - for minor version bump (e.g., 1.0.0 → 1.1.0)`,
+	);
+	parts.push(
+		`- \`${labelPatch}\` - for patch version bump (e.g., 1.0.0 → 1.0.1)`,
+	);
 	parts.push("");
 	parts.push("</details>");
 	parts.push("");
@@ -351,7 +361,10 @@ function buildPRText({
 		// Replace the Full Changelog link with a working View Diff link
 		let modifiedNotes = notes;
 		if (currentTag && nextTag) {
-			const fullChangelogPattern = new RegExp(`\\*\\*Full Changelog\\*\\*: ${serverUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/[^\\/]+\\/[^\\/]+\\/compare\\/[^\\.]+\\.\\.\\.[^\\s]+`, 'g');
+			const fullChangelogPattern = new RegExp(
+				`\\*\\*Full Changelog\\*\\*: ${serverUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\/[^\\/]+\\/[^\\/]+\\/compare\\/[^\\.]+\\.\\.\\.[^\\s]+`,
+				"g",
+			);
 			const viewDiffLink = `**Full Changelog**: ${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}`;
 			modifiedNotes = notes.replace(fullChangelogPattern, viewDiffLink);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,12 +333,11 @@ function buildPRText({
 		parts.push("| **Current Release** | (none) |");
 	}
 
-  const nextTagOrTBD = nextTag || "⚠️ TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
+	const nextTagOrTBD =
+		nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
 
 	// Next tag
-	parts.push(
-		`| **Next Release** | ${nextTagOrTBD} |`,
-	);
+	parts.push(`| **Next Release** | ${nextTagOrTBD} |`);
 
 	// Full changelog link
 	if (currentTag) {
@@ -362,8 +361,8 @@ function buildPRText({
 	);
 	parts.push("");
 	if (notes) {
-    parts.push(`# Release ${nextTagOrTBD}`);
-    parts.push("");
+		parts.push(`# Release ${nextTagOrTBD}`);
+		parts.push("");
 		parts.push(notes);
 	} else {
 		parts.push("_Release notes will be generated here_");
@@ -375,9 +374,9 @@ function buildPRText({
 	const runId = process.env.GITHUB_RUN_ID;
 	const updateTime = new Date().toISOString();
 
-	if (runId && workflow) {
+	if (runId) {
 		const workflowUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
-    parts.push("");
+		parts.push("");
 		parts.push(
 			`<div align="right"><sub>Last updated: <a href="${workflowUrl}">${updateTime}</a> by <a href='https://github.com/actionutils/create-release-pr'>create-release-pr</a></sub></div>`,
 		);

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,7 +304,6 @@ function buildPRText({
 	owner,
 	repo,
 	baseBranch,
-	releaseBranch,
 	currentTag,
 	nextTag,
 	notes,
@@ -312,7 +311,6 @@ function buildPRText({
 	owner: string;
 	repo: string;
 	baseBranch: string;
-	releaseBranch: string;
 	currentTag: string | null;
 	nextTag: string;
 	notes: string;
@@ -321,42 +319,10 @@ function buildPRText({
 	const title = known ? `Release for ${nextTag}` : "Release for new version";
 	const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
 	const parts: string[] = [];
-	// Build the release info table
-	parts.push("<details><summary>Release Information</summary>");
-	parts.push("");
-	parts.push("| | |");
-	parts.push("|---|---|");
-
-	// Current tag with link to release page
-	if (currentTag) {
-		parts.push(
-			`| **Current Release** | [${currentTag}](${serverUrl}/${owner}/${repo}/releases/tag/${currentTag}) |`,
-		);
-	} else {
-		parts.push("| **Current Release** | (none) |");
-	}
 
 	const nextTagOrTBD =
 		nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
 
-	// Next tag
-	parts.push(`| **Next Release** | ${nextTagOrTBD} |`);
-
-	// Release branch
-	parts.push(`| **Release Branch** | [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) |`);
-
-	// Full changelog link
-	if (currentTag) {
-		parts.push(
-			`| **Changes** | [View Diff](${serverUrl}/${owner}/${repo}/compare/${currentTag}...${baseBranch}) |`,
-		);
-	}
-	parts.push("");
-	parts.push("</details>");
-
-	parts.push("");
-	parts.push("---");
-	parts.push("");
 	parts.push("### ↓ Release Notes Preview ↓");
 	parts.push("");
 	if (notes) {
@@ -373,8 +339,6 @@ function buildPRText({
 	} else {
 		parts.push("_Release notes will be generated here_");
 	}
-	parts.push("");
-	parts.push("---");
 
 	// Add workflow update metadata at the end, right-aligned
 	const runId = process.env.GITHUB_RUN_ID;
@@ -463,7 +427,6 @@ async function updateReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
-		releaseBranch: config.releaseBranch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -596,7 +559,6 @@ async function updateExistingReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
-		releaseBranch: config.releaseBranch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -650,7 +612,6 @@ async function createNewReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
-		releaseBranch: config.releaseBranch,
 		currentTag: currentTag?.raw || null,
 		nextTag,
 		notes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,7 @@ function buildPRText({
 	owner,
 	repo,
 	baseBranch,
+	releaseBranch,
 	currentTag,
 	nextTag,
 	notes,
@@ -311,6 +312,7 @@ function buildPRText({
 	owner: string;
 	repo: string;
 	baseBranch: string;
+	releaseBranch: string;
 	currentTag: string | null;
 	nextTag: string;
 	notes: string;
@@ -357,7 +359,7 @@ function buildPRText({
 		"> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.",
 	);
 	parts.push(
-		"> You can directly edit this release-pr branch to prepare for the release.",
+		`> You can directly edit the [${releaseBranch}](https://github.com/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`,
 	);
 	parts.push(
 		"> The Full Changelog link may not work until the new tag is released.",
@@ -460,6 +462,7 @@ async function updateReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
+		releaseBranch: config.releaseBranch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -592,6 +595,7 @@ async function updateExistingReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
+		releaseBranch: config.releaseBranch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -645,6 +649,7 @@ async function createNewReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
+		releaseBranch: config.releaseBranch,
 		currentTag: currentTag?.raw || null,
 		nextTag,
 		notes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,7 @@ function buildPRText({
 	owner,
 	repo,
 	baseBranch,
+	releaseBranch,
 	currentTag,
 	nextTag,
 	notes,
@@ -311,6 +312,7 @@ function buildPRText({
 	owner: string;
 	repo: string;
 	baseBranch: string;
+	releaseBranch: string;
 	currentTag: string | null;
 	nextTag: string;
 	notes: string;
@@ -323,6 +325,8 @@ function buildPRText({
 	const nextTagOrTBD =
 		nextTag || "TBD - Add label: `bump:major`, `bump:minor`, or `bump:patch`";
 
+	parts.push(`You can directly edit the [${releaseBranch}](${serverUrl}/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`);
+	parts.push("");
 	parts.push("### ↓ Release Notes Preview ↓");
 	parts.push("");
 	if (notes) {
@@ -427,6 +431,7 @@ async function updateReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
+		releaseBranch: config.releaseBranch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -559,6 +564,7 @@ async function updateExistingReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
+		releaseBranch: config.releaseBranch,
 		currentTag: releaseInfo.currentTag?.raw || null,
 		nextTag: releaseInfo.nextTag,
 		notes: releaseInfo.notes,
@@ -612,6 +618,7 @@ async function createNewReleasePR(
 		owner: config.owner,
 		repo: config.repo,
 		baseBranch: config.baseBranch,
+		releaseBranch: config.releaseBranch,
 		currentTag: currentTag?.raw || null,
 		nextTag,
 		notes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,16 +355,6 @@ function buildPRText({
 	parts.push("");
 	parts.push("### ↓ Release Notes Preview ↓");
 	parts.push("");
-	parts.push(
-		"> [!NOTE] This is a preview of the release notes that will be published when this PR is merged.",
-	);
-	parts.push(
-		`> You can directly edit the [${releaseBranch}](https://github.com/${owner}/${repo}/tree/${releaseBranch}) branch to prepare for the release.`,
-	);
-	parts.push(
-		"> The Full Changelog link may not work until the new tag is released.",
-	);
-	parts.push("");
 	if (notes) {
 		parts.push(`# Release ${nextTagOrTBD}`);
 		parts.push("");


### PR DESCRIPTION
## Summary
- Simplified the PR body by removing the Release Information table
- Made the release header conditional (only shown when nextTag exists)
- Simplified the Full Changelog link replacement regex for better readability
- Removed unnecessary "Release Notes Preview" header
- Added collapsible instructions for specifying the next version

## Changes
- Removed complex table format in favor of cleaner text layout
- Only show `# Release ${nextTag}` when version is determined
- Simplified regex to directly replace `${currentTag}...${nextTag}` with `${currentTag}...${baseBranch}`
- Fixed unused variable warnings from linter

## Test plan
- [ ] Review PR body format changes
- [ ] Ensure all tests pass
- [ ] Verify release PR creation still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)