### PR TITLE
Fix: Output PR info and release notes for release_required state

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,11 +40,11 @@ outputs:
   state:
     description: release_required | pr_changed | noop
   pr_number:
-    description: Release PR number when state=release_required or state=pr_changed
+    description: Release PR number
   pr_url:
-    description: Release PR URL when state=release_required or state=pr_changed
+    description: Release PR URL
   pr_branch:
-    description: Release branch name when state=pr_changed
+    description: Release branch name (only for pr_changed state)
   current_tag:
     description: Latest parsed tag
   next_tag:
@@ -52,4 +52,4 @@ outputs:
   bump_level:
     description: major | minor | patch | unknown
   release_notes:
-    description: Generated release notes text when state=release_required or state=pr_changed
+    description: Generated release notes text

--- a/action.yml
+++ b/action.yml
@@ -40,9 +40,9 @@ outputs:
   state:
     description: release_required | pr_changed | noop
   pr_number:
-    description: Release PR number when state=pr_changed
+    description: Release PR number when state=release_required or state=pr_changed
   pr_url:
-    description: Release PR URL when state=pr_changed
+    description: Release PR URL when state=release_required or state=pr_changed
   pr_branch:
     description: Release branch name when state=pr_changed
   current_tag:

--- a/action.yml
+++ b/action.yml
@@ -52,4 +52,4 @@ outputs:
   bump_level:
     description: major | minor | patch | unknown
   release_notes:
-    description: Generated release notes text
+    description: Generated release notes text when state=release_required or state=pr_changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -33069,6 +33069,13 @@ function handleMergedReleasePR(octokit, config, relPR) {
             : calcNext(config.tagPrefix, currentTag, bumpLevel);
         if (nextTag)
             core.info(`Release required for: ${nextTag}`);
+        // Generate release notes for the merged PR
+        const notes = yield generateNotes(octokit, config.owner, config.repo, {
+            tagName: nextTag || config.baseBranch,
+            target: config.baseBranch,
+            previousTagName: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || undefined,
+            configuration_file_path: config.releaseCfgPath,
+        }).catch(() => "");
         setReleaseOutputs("release_required", {
             prNumber: String(relPR.number),
             prUrl: relPR.html_url || "",
@@ -33076,7 +33083,7 @@ function handleMergedReleasePR(octokit, config, relPR) {
             currentTag: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || null,
             nextTag,
             bumpLevel,
-            notes: "",
+            notes,
         });
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -33070,8 +33070,8 @@ function handleMergedReleasePR(octokit, config, relPR) {
         if (nextTag)
             core.info(`Release required for: ${nextTag}`);
         setReleaseOutputs("release_required", {
-            prNumber: "",
-            prUrl: "",
+            prNumber: String(relPR.number),
+            prUrl: relPR.html_url || "",
             prBranch: "",
             currentTag: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || null,
             nextTag,

--- a/dist/index.js
+++ b/dist/index.js
@@ -33075,7 +33075,10 @@ function handleMergedReleasePR(octokit, config, relPR) {
             target: config.baseBranch,
             previousTagName: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || undefined,
             configuration_file_path: config.releaseCfgPath,
-        }).catch(() => "");
+        }).catch((err) => {
+            core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+            return "";
+        });
         setReleaseOutputs("release_required", {
             prNumber: String(relPR.number),
             prUrl: relPR.html_url || "",
@@ -33139,7 +33142,10 @@ function createNewReleasePR(octokit, config, currentTag) {
             target: config.baseBranch,
             previousTagName: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || undefined,
             configuration_file_path: config.releaseCfgPath,
-        }).catch(() => "");
+        }).catch((err) => {
+            core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+            return "";
+        });
         const { title, body } = buildPRText({
             owner: config.owner,
             repo: config.repo,
@@ -33195,7 +33201,10 @@ function getReleaseInfo(octokit, config, labels) {
             target: config.baseBranch,
             previousTagName: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || undefined,
             configuration_file_path: config.releaseCfgPath,
-        }).catch(() => "");
+        }).catch((err) => {
+            core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+            return "";
+        });
         return { currentTag, nextTag, bumpLevel, notes };
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -574,7 +574,10 @@ async function handleMergedReleasePR(
 		target: config.baseBranch,
 		previousTagName: currentTag?.raw || undefined,
 		configuration_file_path: config.releaseCfgPath,
-	}).catch(() => "");
+	}).catch((err) => {
+		core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+		return "";
+	});
 
 	setReleaseOutputs("release_required", {
 		prNumber: String(relPR.number),
@@ -655,7 +658,10 @@ async function createNewReleasePR(
 		target: config.baseBranch,
 		previousTagName: currentTag?.raw || undefined,
 		configuration_file_path: config.releaseCfgPath,
-	}).catch(() => "");
+	}).catch((err) => {
+		core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+		return "";
+	});
 
 	const { title, body } = buildPRText({
 		owner: config.owner,
@@ -729,7 +735,10 @@ async function getReleaseInfo(
 		target: config.baseBranch,
 		previousTagName: currentTag?.raw || undefined,
 		configuration_file_path: config.releaseCfgPath,
-	}).catch(() => "");
+	}).catch((err) => {
+		core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+		return "";
+	});
 
 	return { currentTag, nextTag, bumpLevel, notes };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -569,8 +569,8 @@ async function handleMergedReleasePR(
 	if (nextTag) core.info(`Release required for: ${nextTag}`);
 
 	setReleaseOutputs("release_required", {
-		prNumber: "",
-		prUrl: "",
+		prNumber: String(relPR.number),
+		prUrl: relPR.html_url || "",
 		prBranch: "",
 		currentTag: currentTag?.raw || null,
 		nextTag,

--- a/src/index.ts
+++ b/src/index.ts
@@ -568,6 +568,14 @@ async function handleMergedReleasePR(
 			: calcNext(config.tagPrefix, currentTag, bumpLevel);
 	if (nextTag) core.info(`Release required for: ${nextTag}`);
 
+	// Generate release notes for the merged PR
+	const notes = await generateNotes(octokit, config.owner, config.repo, {
+		tagName: nextTag || config.baseBranch,
+		target: config.baseBranch,
+		previousTagName: currentTag?.raw || undefined,
+		configuration_file_path: config.releaseCfgPath,
+	}).catch(() => "");
+
 	setReleaseOutputs("release_required", {
 		prNumber: String(relPR.number),
 		prUrl: relPR.html_url || "",
@@ -575,7 +583,7 @@ async function handleMergedReleasePR(
 		currentTag: currentTag?.raw || null,
 		nextTag,
 		bumpLevel,
-		notes: "",
+		notes,
 	});
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -575,7 +575,9 @@ async function handleMergedReleasePR(
 		previousTagName: currentTag?.raw || undefined,
 		configuration_file_path: config.releaseCfgPath,
 	}).catch((err) => {
-		core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+		core.warning(
+			`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`,
+		);
 		return "";
 	});
 
@@ -659,7 +661,9 @@ async function createNewReleasePR(
 		previousTagName: currentTag?.raw || undefined,
 		configuration_file_path: config.releaseCfgPath,
 	}).catch((err) => {
-		core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+		core.warning(
+			`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`,
+		);
 		return "";
 	});
 
@@ -736,7 +740,9 @@ async function getReleaseInfo(
 		previousTagName: currentTag?.raw || undefined,
 		configuration_file_path: config.releaseCfgPath,
 	}).catch((err) => {
-		core.warning(`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`);
+		core.warning(
+			`Failed to generate release notes: ${err instanceof Error ? err.message : String(err)}`,
+		);
 		return "";
 	});
 


### PR DESCRIPTION
## Summary
- Added pr_number, pr_url, and release_notes outputs for the release_required state
- Simplified action.yml output descriptions by removing redundant state conditions
- pr_branch remains specific to pr_changed state only (since branch may be deleted after merge)

## Changes
1. Modified `handleMergedReleasePR` to include PR number, URL, and generate release notes
2. Updated action.yml documentation to clarify output availability
3. Built and included the compiled dist/index.js

## Test plan
- [ ] Verify that when a release PR is merged, the action outputs include pr_number, pr_url, and release_notes
- [ ] Confirm pr_branch is not output for release_required state
- [ ] Check that all outputs work correctly for pr_changed state

🤖 Generated with [Claude Code](https://claude.ai/code)