### PR TITLE
fix: require bump label when release PR is merged

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33064,14 +33064,16 @@ function handleMergedReleasePR(octokit, config, relPR) {
             labelPatch: config.labelPatch,
         });
         core.info(`Detected bump level: ${bumpLevel}`);
-        const nextTag = bumpLevel === "unknown"
-            ? ""
-            : calcNext(config.tagPrefix, currentTag, bumpLevel);
-        if (nextTag)
-            core.info(`Release required for: ${nextTag}`);
+        // Error if no bump level is specified
+        if (bumpLevel === "unknown") {
+            throw new Error(`Release PR #${relPR.number} was merged without a bump label. ` +
+                `Please add one of the following labels: ${config.labelMajor}, ${config.labelMinor}, or ${config.labelPatch}`);
+        }
+        const nextTag = calcNext(config.tagPrefix, currentTag, bumpLevel);
+        core.info(`Release required for: ${nextTag}`);
         // Generate release notes for the merged PR
         const notes = yield generateNotes(octokit, config.owner, config.repo, {
-            tagName: nextTag || config.baseBranch,
+            tagName: nextTag,
             target: config.baseBranch,
             previousTagName: (currentTag === null || currentTag === void 0 ? void 0 : currentTag.raw) || undefined,
             configuration_file_path: config.releaseCfgPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -562,15 +562,20 @@ async function handleMergedReleasePR(
 	});
 	core.info(`Detected bump level: ${bumpLevel}`);
 
-	const nextTag =
-		bumpLevel === "unknown"
-			? ""
-			: calcNext(config.tagPrefix, currentTag, bumpLevel);
-	if (nextTag) core.info(`Release required for: ${nextTag}`);
+	// Error if no bump level is specified
+	if (bumpLevel === "unknown") {
+		throw new Error(
+			`Release PR #${relPR.number} was merged without a bump label. ` +
+				`Please add one of the following labels: ${config.labelMajor}, ${config.labelMinor}, or ${config.labelPatch}`,
+		);
+	}
+
+	const nextTag = calcNext(config.tagPrefix, currentTag, bumpLevel);
+	core.info(`Release required for: ${nextTag}`);
 
 	// Generate release notes for the merged PR
 	const notes = await generateNotes(octokit, config.owner, config.repo, {
-		tagName: nextTag || config.baseBranch,
+		tagName: nextTag,
 		target: config.baseBranch,
 		previousTagName: currentTag?.raw || undefined,
 		configuration_file_path: config.releaseCfgPath,


### PR DESCRIPTION
## Summary
- Add validation to fail the action when a release PR is merged without a bump label
- Prevents releases from proceeding without a specified version bump level (major/minor/patch)
- Provides clear error message indicating which labels are required

## Test plan
- [ ] Verify the action fails when merging a release PR without bump labels
- [ ] Confirm error message clearly states the required labels
- [ ] Ensure normal operation continues when proper bump label is present

🤖 Generated with [Claude Code](https://claude.ai/code)