### PR TITLE
fix: remove unimplemented pr_status_check state and status_check_state output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
   main: dist/index.js
 outputs:
   state:
-    description: release_required | pr_changed | pr_status_check | noop
+    description: release_required | pr_changed | noop
   pr_number:
     description: Release PR number
   pr_url:
@@ -53,5 +53,3 @@ outputs:
     description: major | minor | patch | unknown
   release_notes:
     description: Generated release notes text
-  status_check_state:
-    description: Status check state (success | pending) when state is pr_status_check


### PR DESCRIPTION
## Summary
- Remove `pr_status_check` from state output description
- Remove `status_check_state` output entirely
- These were defined in action.yml but never implemented in the TypeScript code

## Context
The actual implementation only uses three states:
- `release_required` - when a release is needed
- `pr_changed` - when a PR is updated
- `noop` - when no action is needed

The `pr_status_check` state and `status_check_state` output were never implemented.

## Test plan
- [ ] Verify action.yml is valid YAML
- [ ] Check that the three implemented states still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)