### PR TITLE
refactor: rename state 'pr_changed' to 'release_pr_open'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,13 +38,13 @@ runs:
   main: dist/index.js
 outputs:
   state:
-    description: release_required | pr_changed | noop
+    description: release_required | release_pr_open | noop
   pr_number:
     description: Release PR number
   pr_url:
     description: Release PR URL
   pr_branch:
-    description: Release branch name (only for pr_changed state)
+    description: Release branch name (only for release_pr_open state)
   current_tag:
     description: Latest parsed tag
   next_tag:

--- a/dist/index.js
+++ b/dist/index.js
@@ -33050,7 +33050,7 @@ function updateReleasePR(octokit, config, pr) {
             body,
         });
         core.info("PR updated successfully");
-        setReleaseOutputs("pr_changed", {
+        setReleaseOutputs("release_pr_open", {
             prNumber: String(pr.number),
             prUrl: pr.html_url,
             prBranch: config.releaseBranch,
@@ -33178,7 +33178,7 @@ function createNewReleasePR(octokit, config, currentTag) {
         });
         core.info(`Created release PR #${created.number}`);
         yield ensureAndAddLabel(octokit, config.owner, config.repo, created.number, "release-pr");
-        setReleaseOutputs("pr_changed", {
+        setReleaseOutputs("release_pr_open", {
             prNumber: String(created.number),
             prUrl: created.html_url,
             prBranch: config.releaseBranch,

--- a/docs/design.md
+++ b/docs/design.md
@@ -74,11 +74,11 @@
 ## Outputs
 - `state`: One of:
   - `release_required` — release PR was (already) merged and a release should occur (by other automation). No open release PR exists now.
-  - `pr_changed` — a release PR was created or updated in this run.
+  - `release_pr_open` — a release PR was created or updated in this run.
   - `pr_status_check` — status check was set on the release PR (no other changes made).
-- `pr_number`: Release PR number when `state=pr_changed` or `pr_status_check`, otherwise empty.
-- `pr_url`: Release PR URL when `state=pr_changed` or `pr_status_check`, otherwise empty.
-- `pr_branch`: Release branch name when `state=pr_changed`, otherwise empty.
+- `pr_number`: Release PR number when `state=release_pr_open` or `pr_status_check`, otherwise empty.
+- `pr_url`: Release PR URL when `state=release_pr_open` or `pr_status_check`, otherwise empty.
+- `pr_branch`: Release branch name when `state=release_pr_open`, otherwise empty.
 - `current_tag`: Latest parsed tag (empty if none).
 - `next_tag`: When determinable; empty if unknown.
 - `bump_level`: `major|minor|patch|unknown` — label-derived when available.

--- a/src/index.ts
+++ b/src/index.ts
@@ -555,7 +555,7 @@ async function updateReleasePR(
 	});
 
 	core.info("PR updated successfully");
-	setReleaseOutputs("pr_changed", {
+	setReleaseOutputs("release_pr_open", {
 		prNumber: String(pr.number),
 		prUrl: pr.html_url,
 		prBranch: config.releaseBranch,
@@ -722,7 +722,7 @@ async function createNewReleasePR(
 		"release-pr",
 	);
 
-	setReleaseOutputs("pr_changed", {
+	setReleaseOutputs("release_pr_open", {
 		prNumber: String(created.number),
 		prUrl: created.html_url,
 		prBranch: config.releaseBranch,


### PR DESCRIPTION
## Summary
- Renamed the state name from `pr_changed` to `release_pr_open` for better clarity
- Updated all references in source code, action.yml, and documentation

## Motivation
The previous state name `pr_changed` was ambiguous as it suggested something changed, but the state actually represents that there's an open release PR (whether newly created or updated). The new name `release_pr_open` is more descriptive and clearly indicates the actual state.

## Test plan
- [ ] Existing tests should pass without modification
- [ ] Action continues to work as expected with the new state name

🤖 Generated with [Claude Code](https://claude.ai/code)