### PR TITLE
feat: add skip-release-notes option for customizable PR descriptions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
   configuration_file_path:
     description: Optional path to release notes configuration (e.g., .github/release.yml)
     required: false
+  skip-release-notes:
+    description: Skip adding release notes to PR description (useful for custom workflows)
+    required: false
+    default: 'false'
   github-token:
     description: GitHub token
     required: true


### PR DESCRIPTION
## Summary
- Added `skip-release-notes` input parameter to optionally skip adding release notes to PR description
- Release notes are still generated and available via the `release_notes` output
- Enables users to customize release notes and PR descriptions for their specific workflows

## Details
This PR introduces a new optional input parameter `skip-release-notes` (defaults to `false`) that allows users to prevent release notes from being added to the PR description. 

When enabled:
- The PR description will only contain the branch edit link and version bump instructions
- Release notes are still generated and exposed through the `release_notes` output
- Users can then use the output to customize the release notes as needed (e.g., post as a comment, modify before adding, etc.)

This provides more flexibility for users who want to:
- Customize the release note format
- Add additional information to release notes
- Use release notes in different ways (comments, external systems, etc.)

## Test plan
- [ ] Test with `skip-release-notes: false` (default) - release notes should appear in PR description
- [ ] Test with `skip-release-notes: true` - release notes should not appear in PR description but should be in output
- [ ] Verify `release_notes` output contains the generated notes in both cases
- [ ] Ensure existing functionality is not broken

🤖 Generated with [Claude Code](https://claude.ai/code)