### PR TITLE
feat: add formatted dependency JSON to release PR comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,22 @@ jobs:
       - name: Comment dependency review result
         env:
           BODY: ${{ steps.dependency-review.outputs.comment-content }}
+          DEP_JSON: ${{ steps.dependency-review.outputs.dependency-changes }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          FORMATTED_JSON=$(echo "${DEP_JSON}" | jq .)
+          FULL_BODY="${BODY}
+
+          <details>
+          <summary>Dependency Changes (JSON)</summary>
+
+          <pre>${FORMATTED_JSON}</pre>
+          </details>"
+
           github-comment post --pr ${{ fromJSON(needs.release-pr.outputs.release_pr).pr_number }} \
             -k dep-review \
             --update-condition 'Comment.HasMeta && Comment.Meta.TemplateKey == "dep-review"' \
-            --template "${BODY}"
+            --template "${FULL_BODY}"
 
   verify-releaser:
     needs: [release-pr]


### PR DESCRIPTION
## Summary
- Add dependency-changes JSON output from dependency-review-action to github-comment body
- Format JSON with jq for readability
- Wrap JSON in collapsible details section to avoid cluttering the comment

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm jq is available in ubuntu-latest runner
- [ ] Test that github-comment correctly handles the multi-line template with details/pre tags
- [ ] Verify the comment appears correctly formatted in a release PR

🤖 Generated with [Claude Code](https://claude.ai/code)