### PR TITLE
feat: create release PRs as draft by default

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33179,7 +33179,7 @@ function createNewReleasePR(octokit, config, currentTag) {
             head: config.releaseBranch,
             base: config.baseBranch,
             body,
-            draft: false,
+            draft: true,
         });
         core.info(`Created release PR #${created.number}`);
         yield ensureAndAddLabel(octokit, config.owner, config.repo, created.number, "release-pr");

--- a/src/index.ts
+++ b/src/index.ts
@@ -718,7 +718,7 @@ async function createNewReleasePR(
 		head: config.releaseBranch,
 		base: config.baseBranch,
 		body,
-		draft: false,
+		draft: true,
 	});
 
 	core.info(`Created release PR #${created.number}`);


### PR DESCRIPTION
## Summary
- Changed release PRs to be created as drafts by default
- This allows users to manually mark PRs as "Ready for Review" when they're ready
- Marking as ready will trigger GitHub Actions workflows, providing better control

## Benefits
- Better control over when GitHub Actions are triggered
- Users can prepare release PRs without immediately triggering workflows
- Subsequent workflow runs can be triggered by marking the PR as ready for review

## Changes
- Modified `draft: false` to `draft: true` in the `createNewReleasePR` function
- Built and committed the compiled JavaScript output

🤖 Generated with [Claude Code](https://claude.ai/code)