### PR TITLE
feat: trigger CI workflows on ready_for_review event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,9 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,7 @@ name: E2E Test
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## Summary
- Added `ready_for_review` event to pull_request triggers for all CI workflows
- Ensures CI runs when draft PRs are marked as ready for review

## Benefits
- Draft release PRs created by GitHub Actions will trigger CI when marked as ready
- Better control over when CI runs for draft PRs
- Complements the draft PR feature added in #56

## Changes
- Updated CI workflow to include `ready_for_review` in pull_request event types
- Updated E2E Test workflow to include `ready_for_review` in pull_request event types  
- Updated Dependency Review workflow to include `ready_for_review` in pull_request event types

🤖 Generated with [Claude Code](https://claude.ai/code)