### PR TITLE
feat: add workflow run URL to status checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -344,6 +344,18 @@ async function ensureReleaseBranch(
 	);
 }
 
+// Helper to get workflow run URL
+function getWorkflowRunUrl(): string | undefined {
+	const runId = process.env.GITHUB_RUN_ID;
+	if (!runId) return undefined;
+
+	const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!repository) return undefined;
+
+	return `${serverUrl}/${repository}/actions/runs/${runId}`;
+}
+
 // Unified status helper for setting commit statuses
 async function setCommitStatus(
 	octokit: ReturnType<typeof getOctokit>,
@@ -353,6 +365,7 @@ async function setCommitStatus(
 	context: string,
 	state: "error" | "failure" | "pending" | "success",
 	description: string,
+	targetUrl?: string,
 ): Promise<void> {
 	try {
 		await octokit.rest.repos.createCommitStatus({
@@ -362,6 +375,7 @@ async function setCommitStatus(
 			state,
 			description: description.substring(0, 140), // GitHub limits to 140 chars
 			context,
+			target_url: targetUrl,
 		});
 		core.info(`Status check set [${context}]: ${state} - ${description}`);
 	} catch (err) {
@@ -391,6 +405,7 @@ async function setCommitStatusForBumpLabel(
 		"create-release-pr/bump-label",
 		state,
 		description,
+		getWorkflowRunUrl(),
 	);
 }
 
@@ -430,6 +445,7 @@ async function setReleaseBranchUpdateStatus(
 		"create-release-pr/branch-update",
 		state,
 		description,
+		getWorkflowRunUrl(),
 	);
 }
 


### PR DESCRIPTION
## Summary
- Add workflow run URL as target_url to commit status checks
- Users can now click on status checks to navigate directly to the running GitHub Actions workflow

## Changes
- Added `getWorkflowRunUrl()` helper function to construct workflow URL from environment variables
- Updated `setCommitStatus()` to accept optional `targetUrl` parameter
- Pass workflow URL to all status check updates

## Test plan
- [ ] Verify status checks show clickable link to workflow run
- [ ] Confirm link navigates to correct GitHub Actions run
- [ ] Test with both bump-label and branch-update status checks

🤖 Generated with [Claude Code](https://claude.ai/code)