### PR TITLE
feat: add workflow_dispatch event support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main  # Only run on main branch pushes (PR merges)
   pull_request:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Added support for `workflow_dispatch` events to allow manual triggering of release PR creation/updates
- Refactored push event handler to share code between push and workflow_dispatch events
- Both event types now follow identical logic for managing release PRs

## Changes
- Renamed `handlePushEvent` to `handlePushOrDispatchEvent` to support both event types
- Added logic to extract head SHA from appropriate source (`payload.after` for push, `context.sha` for workflow_dispatch)
- Enables manual workflow triggers to create or update release PRs just like push events do

## Test plan
- [ ] Test with workflow_dispatch event to create new release PR
- [ ] Test with workflow_dispatch event to update existing release PR
- [ ] Verify push events still work as expected
- [ ] Confirm merged release PR detection works for both event types

🤖 Generated with [Claude Code](https://claude.ai/code)