### PR TITLE
fix: set commit status when creating new release PR

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33271,12 +33271,14 @@ function createNewReleasePR(octokit, config, currentTag, releaseBranch) {
                 bumpLevel,
                 notes,
             });
-            // Return the PR head SHA for status update
+            // Get the PR head SHA for status update
             const { data: prData } = yield octokit.rest.pulls.get({
                 owner: config.owner,
                 repo: config.repo,
                 pull_number: created.number,
             });
+            // Set commit status for the initial unknown bump level
+            yield setCommitStatusForBumpLabel(octokit, config, prData.head.sha, bumpLevel);
             return prData.head.sha;
         }));
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -938,12 +938,21 @@ async function createNewReleasePR(
 				notes,
 			});
 
-			// Return the PR head SHA for status update
+			// Get the PR head SHA for status update
 			const { data: prData } = await octokit.rest.pulls.get({
 				owner: config.owner,
 				repo: config.repo,
 				pull_number: created.number,
 			});
+
+			// Set commit status for the initial unknown bump level
+			await setCommitStatusForBumpLabel(
+				octokit,
+				config,
+				prData.head.sha,
+				bumpLevel,
+			);
+
 			return prData.head.sha;
 		},
 	);


### PR DESCRIPTION
## Summary
- Add missing `setCommitStatusForBumpLabel` call when creating a new release PR
- Ensures commit status is properly set for the initial "unknown" bump level

## Problem
The `setCommitStatusForBumpLabel` function was only being called when updating an existing release PR but not when creating a new one. This meant that newly created release PRs wouldn't have their commit status set until a label was added/changed.

## Solution
Added the `setCommitStatusForBumpLabel` call in the `createNewReleasePR` function after retrieving the PR head SHA, ensuring the commit status is set immediately upon PR creation.

## Test plan
- [ ] Create a new release PR and verify commit status is set
- [ ] Update an existing release PR and confirm status updates work as before
- [ ] Add/change bump labels and ensure status updates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)